### PR TITLE
H4 and h6 styles

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -287,6 +287,10 @@ html, body {
     margin-top: 1.5em;
     margin-bottom: 0.5em;
   }
+  
+  h6 {
+    display:none;
+  }
 
   hr {
     margin: 2em 0;


### PR DESCRIPTION
Styles for h4 headers and setting display:none for h6, so that it can be used to mark subsections that don't need a header, e.g. when one article has many code snippets per heading.
